### PR TITLE
Restricted gapps domain support

### DIFF
--- a/src/main/java/org/sonar/plugins/openid/GoogleDomainDiscovery.java
+++ b/src/main/java/org/sonar/plugins/openid/GoogleDomainDiscovery.java
@@ -1,0 +1,50 @@
+package org.sonar.plugins.openid;
+
+import org.openid4java.discovery.Discovery;
+import org.openid4java.discovery.DiscoveryException;
+import org.openid4java.discovery.DiscoveryInformation;
+import org.openid4java.discovery.Identifier;
+import org.openid4java.discovery.UrlIdentifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Code below adapted from Jenkins OpenID plugin at
+ * https://github.com/jenkinsci/openid-plugin/blob/master/src/main/java/hudson/plugins/openid/GoogleAppSsoSecurityRealm.java
+ * 
+ * Original authors Kohsuke Kawaguchi and Stephen Connoly
+ * 
+ * @author Nick Spacek
+ *
+ */
+public class GoogleDomainDiscovery extends Discovery {
+  private String domain;
+
+  public GoogleDomainDiscovery(String domain) {
+    super();
+    this.domain = domain;
+  }
+  
+  @Override
+  public List discover(Identifier id) throws DiscoveryException {
+    if (id.getIdentifier().startsWith("http://" + domain + '/') && id instanceof UrlIdentifier) {
+      String source = "https://www.google.com/accounts/o8/user-xrds?uri=" + id.getIdentifier();
+      List<DiscoveryInformation> r = super.discover(new UrlIdentifier(source));
+      List<DiscoveryInformation> x = new ArrayList<DiscoveryInformation>();
+      for (DiscoveryInformation discovered : r) {
+        if (discovered.getClaimedIdentifier().getIdentifier().equals(source)) {
+          discovered = new DiscoveryInformation(discovered.getOPEndpoint(),
+            id,
+            discovered.getDelegateIdentifier(),
+            discovered.getVersion(),
+            discovered.getTypes()
+          );
+        }
+        x.add(discovered);
+      }
+      return x;
+    }
+    return super.discover(id);
+  }
+}

--- a/src/test/java/org/sonar/plugins/openid/OpenIdClientTest.java
+++ b/src/test/java/org/sonar/plugins/openid/OpenIdClientTest.java
@@ -66,11 +66,20 @@ public class OpenIdClientTest {
   }
 
   @Test
-  public void initDiscoveryInfo_fail_if_missing_url() {
+  public void initDiscoveryInfo_fail_if_missing_url_and_domain() {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Property sonar.openid.providerUrl is missing");
 
     OpenIdClient client = new OpenIdClient(new Settings());
+    client.start();
+  }
+  
+  @Test
+  public void initDiscoveryInfo_succeed_if_domain_specified() {
+    Settings settings = new Settings().setProperty(OpenIdClient.PROPERTY_SONAR_URL, "http://localhost:9000")
+        .setProperty(OpenIdClient.PROPERTY_OPENID_GOOGLE_DOMAIN, "lashpoint.com");
+
+    OpenIdClient client = new OpenIdClient(settings);
     client.start();
   }
 


### PR DESCRIPTION
Here is support for restricting the Google OpenID support to particular domains. It adds two new configuration properties:

    sonar.openid.google.domain=lashpoint.com
    # optional, defaults to the below value
    sonar.openid.google.endpoint=https://www.google.com/accounts/o8/site-xrds?hd=