### PR TITLE
Fallback to Simple Registration 1.1 when version 1.0 is not available

### DIFF
--- a/src/main/java/org/sonar/plugins/openid/OpenIdClient.java
+++ b/src/main/java/org/sonar/plugins/openid/OpenIdClient.java
@@ -192,6 +192,9 @@ public class OpenIdClient implements ServerExtension {
       String email = null;
 
       SRegResponse sr = OpenIdUtils.getMessageAs(SRegResponse.class, authSuccess, SRegMessage.OPENID_NS_SREG);
+      if (sr == null) {
+        sr = OpenIdUtils.getMessageAs(SRegResponse.class, authSuccess, SRegMessage.OPENID_NS_SREG11);
+      }
       if (sr != null) {
         name = sr.getAttributeValue(SREG_ATTR_FULLNAME);
         email = sr.getAttributeValue(SREG_ATTR_EMAIL);

--- a/src/test/java/org/sonar/plugins/openid/OpenIdClientTest.java
+++ b/src/test/java/org/sonar/plugins/openid/OpenIdClientTest.java
@@ -135,6 +135,21 @@ public class OpenIdClientTest {
   }
 
   @Test
+  public void toUserDetails_sreg11_attributes() throws Exception {
+    AuthSuccess authSuccess = mock(AuthSuccess.class);
+    when(authSuccess.hasExtension(SRegMessage.OPENID_NS_SREG11)).thenReturn(true);
+    SRegResponse sreg = SRegResponse.createFetchResponse();
+    sreg.addAttribute("fullname", "Dee Dee MacCall");
+    sreg.addAttribute("email", "deedee@maccall.com");
+    when(authSuccess.getExtension(SRegMessage.OPENID_NS_SREG11)).thenReturn(sreg);
+
+    UserDetails user = OpenIdClient.toUser(authSuccess);
+
+    assertThat(user.getName()).isEqualTo("Dee Dee MacCall");
+    assertThat(user.getEmail()).isEqualTo("deedee@maccall.com");
+  }
+
+  @Test
   public void toUserDetails_missing_fields() throws Exception {
     AuthSuccess authSuccess = mock(AuthSuccess.class);
     when(authSuccess.hasExtension(SRegMessage.OPENID_NS_SREG)).thenReturn(true);


### PR DESCRIPTION
The plugin only supports Simple Registration version 1.0 attributes. This small patch also tries to fetch Simple Registration 1.1 when the 1.0 attributes are not available.
